### PR TITLE
Fix ART slide: real Okoloto & Elemnts images + viewport-fit layout

### DIFF
--- a/src/features/gallery/Slide4Collections.tsx
+++ b/src/features/gallery/Slide4Collections.tsx
@@ -1,61 +1,99 @@
 import { motion } from 'framer-motion'
-import { MediaRenderer } from 'thirdweb/react'
-import { useStore } from '../../hooks/useStore'
 
 const Slide4Collections = () => {
-  const { client } = useStore()
-
   const artworks = [
-    { id: 1, title: 'Okoloto #001', color: 'from-purple-500 to-pink-500' },
-    { id: 2, title: 'Okoloto #002', color: 'from-blue-500 to-cyan-500' },
-    { id: 3, title: 'Elemnts #001', color: 'from-orange-500 to-yellow-500' },
-    { id: 4, title: 'Elemnts #002', color: 'from-green-500 to-emerald-500' },
-    { id: 5, title: 'Okoloto #003', color: 'from-red-500 to-pink-500' },
-    { id: 6, title: 'Elemnts #003', color: 'from-indigo-500 to-purple-500' },
+    {
+      id: 1,
+      title: 'Okoloto #001',
+      color: 'from-purple-500 to-pink-500',
+      image: 'https://ipfs.io/ipfs/Qmdaiju45QxWibywnWftvKQgxPy1TJxBuGEUQa4Fevv9Sf/640.jpg',
+      link: 'https://opensea.io/collection/okoloto',
+    },
+    {
+      id: 2,
+      title: 'Okoloto #002',
+      color: 'from-blue-500 to-cyan-500',
+      image: 'https://ipfs.io/ipfs/Qmdaiju45QxWibywnWftvKQgxPy1TJxBuGEUQa4Fevv9Sf/265.jpg',
+      link: 'https://opensea.io/collection/okoloto',
+    },
+    {
+      id: 3,
+      title: 'Elemnts #001',
+      color: 'from-orange-500 to-yellow-500',
+      image: 'https://arweave.net/PLfqR9j24VXlek1oNotBkYrrRH_IiQQKDjmrsvAEEQc',
+      link: 'https://opensea.io/collection/elemntsbyohnahji',
+    },
+    {
+      id: 4,
+      title: 'Elemnts #002',
+      color: 'from-green-500 to-emerald-500',
+      image: 'https://arweave.net/G87rtS-Mt-erTUE3aZZVwTfQ2fO4USetBEz8SmARM_M',
+      link: 'https://opensea.io/collection/elemntsbyohnahji',
+    },
+    {
+      id: 5,
+      title: 'Okoloto #003',
+      color: 'from-red-500 to-pink-500',
+      image: 'https://ipfs.io/ipfs/Qmdaiju45QxWibywnWftvKQgxPy1TJxBuGEUQa4Fevv9Sf/1737.jpg',
+      link: 'https://opensea.io/collection/okoloto',
+    },
+    {
+      id: 6,
+      title: 'Elemnts #003',
+      color: 'from-indigo-500 to-purple-500',
+      image: 'https://arweave.net/8obmakSPrhbjzUwImpC9MKBXamQ7uFvSKCe-bU8W0MA',
+      link: 'https://opensea.io/collection/elemntsbyohnahji',
+    },
   ]
 
   return (
-    <div className="min-h-full flex items-center justify-center py-8">
-      <div className="max-w-6xl w-full">
+    <div className="h-full flex flex-col items-center justify-center py-2 md:py-4">
+      <div className="max-w-5xl w-full flex flex-col h-full max-h-full">
         <motion.div
-          initial={{ opacity: 0, y: -50 }}
+          initial={{ opacity: 0, y: -30 }}
           whileInView={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8 }}
-          className="text-center mb-6 md:mb-12"
+          className="text-center mb-3 md:mb-5"
         >
-          <div className="inline-block bg-ohnahji-pink text-ohnahji-white px-6 py-2 border-[6px] border-ohnahji-black rounded-2xl mb-6 font-sans">
-            <span className="text-sm font-bold uppercase tracking-wider">GENERATIVE ART</span>
+          <div className="inline-block bg-ohnahji-pink text-ohnahji-white px-4 py-1 border-[6px] border-ohnahji-black rounded-2xl mb-3 font-sans">
+            <span className="text-xs font-bold uppercase tracking-wider">GENERATIVE ART</span>
           </div>
-          <h1 className="text-5xl md:text-7xl font-black text-ohnahji-gold mb-4 leading-none">
+          <h1 className="text-4xl md:text-5xl font-black text-ohnahji-gold mb-2 leading-none">
             OKOLOTOS & ELEMNTS
           </h1>
-          <p className="text-xl text-ohnahji-white font-bold font-sans">
+          <p className="text-base text-ohnahji-white font-bold font-sans">
             Code-based artistic expression
           </p>
         </motion.div>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+        <div
+          className="grid grid-cols-3 grid-rows-2 gap-2 md:gap-3 flex-1 min-h-0"
+          onWheel={(e) => e.stopPropagation()}
+        >
           {artworks.map((art, index) => (
-            <motion.div
+            <motion.a
               key={art.id}
-              initial={{ opacity: 0, y: 50 }}
+              href={art.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: index * 0.1 }}
               whileHover={{ scale: 1.05, zIndex: 10 }}
-              className={`neo-card p-4 bg-gradient-to-br ${art.color} rounded-3xl cursor-pointer group`}
+              className={`neo-card p-1.5 md:p-2 bg-gradient-to-br ${art.color} rounded-xl md:rounded-2xl cursor-pointer group flex flex-col min-h-0`}
             >
-              <div className="aspect-square border-[6px] border-ohnahji-black flex items-center justify-center mb-4 rounded-2xl overflow-hidden bg-white/20 relative">
-                <div className="absolute inset-0 bg-white/10 animate-pulse group-hover:hidden" />
-                <MediaRenderer
-                  client={client}
-                  src={`ipfs://QmZJv7nQ9YQXA9yFfX8U1eGqVvR9pW5J3kRk3nN5mX1Y1/${art.id}.png`}
+              <div className="flex-1 min-h-0 border-4 border-ohnahji-black flex items-center justify-center mb-1 rounded-lg md:rounded-xl overflow-hidden bg-white/20 relative">
+                <img
+                  src={art.image}
+                  alt={art.title}
+                  loading="lazy"
                   className="w-full h-full object-cover"
                 />
               </div>
-              <div className="bg-ohnahji-white border-[6px] border-ohnahji-black p-3 rounded-xl shadow-neo-sm group-hover:shadow-neo transition-all">
-                <p className="font-black text-center font-sans uppercase text-sm tracking-tighter">{art.title}</p>
+              <div className="bg-ohnahji-white border-4 border-ohnahji-black p-1 rounded-lg shadow-neo-sm group-hover:shadow-neo transition-all shrink-0">
+                <p className="font-black text-center font-sans uppercase text-[9px] md:text-[11px] tracking-tighter">{art.title}</p>
               </div>
-            </motion.div>
+            </motion.a>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary

The ART slide (Slide 4) was completely broken — all 6 cards showed "File" placeholder text instead of artwork, and scrolling through the cards triggered unintended slide navigation. This PR fixes both issues.

## What Was Wrong

### Broken Images
The component used Thirdweb's `MediaRenderer` with a **non-existent IPFS CID** (`QmZJv7nQ9YQXA9yFfX8U1eGqVvR9pW5J3kRk3nN5mX1Y1`). This CID was never uploaded to IPFS, so all 6 art cards rendered as blank white boxes with a "File" fallback.

### Layout Overflow & Scroll Conflict
The grid used `min-h-full` with large padding/gaps, causing the 2×3 card grid to overflow the viewport vertically. Users had to scroll down to see the bottom 3 cards, but vertical scroll events were captured by the horizontal slide navigation handler — scrolling down would jump to the next slide instead of revealing the hidden cards.

## What This PR Does

### 1. Real NFT Art from On-Chain Metadata

Replaced `MediaRenderer` with standard `<img>` tags using verified image URLs fetched directly from each collection's smart contract:

| Card | Collection | Chain | Image Source |
|------|-----------|-------|-------------|
| Okoloto #001 | [Okoloto](https://opensea.io/collection/okoloto) | Base | IPFS (`Qmdaiju45Q.../640.jpg`) |
| Okoloto #002 | [Okoloto](https://opensea.io/collection/okoloto) | Base | IPFS (`Qmdaiju45Q.../265.jpg`) |
| Okoloto #003 | [Okoloto](https://opensea.io/collection/okoloto) | Base | IPFS (`Qmdaiju45Q.../1737.jpg`) |
| Elemnts #001 | [Elemnts](https://opensea.io/collection/elemntsbyohnahji) | Base | Arweave (`PLfqR9j2...`) |
| Elemnts #002 | [Elemnts](https://opensea.io/collection/elemntsbyohnahji) | Base | Arweave (`G87rtS-M...`) |
| Elemnts #003 | [Elemnts](https://opensea.io/collection/elemntsbyohnahji) | Base | Arweave (`8obmakSP...`) |

**Contract addresses:**
- Okoloto: `0x70848d1e0ed7f946d6f238fe8fa1db08b0aaebe1`
- Elemnts: `0x9d378b606e3409893c63e45de3f9fdb7cf57ebee`

### 2. Viewport-Constrained Layout (No More Overflow)

- Outer container: `h-full` (was `min-h-full`) — constrains to viewport height
- Inner wrapper: `flex flex-col h-full max-h-full` — children fill but never exceed space
- Grid: `grid-cols-3 grid-rows-2 flex-1 min-h-0` — explicit 2-row layout that shrinks to fit
- Cards: `flex flex-col min-h-0` with flexible image containers — images scale down proportionally
- Always 3 columns on all screen sizes (removed 2-col mobile breakpoint)
- `onWheel` stop propagation on grid prevents scroll events from reaching slide navigator

### 3. Cards Now Link to OpenSea

Each card is now a clickable `<a>` (was `<div>`) that opens the respective OpenSea collection page in a new tab.

### 4. Cleanup

- Removed unused `MediaRenderer` import from `thirdweb/react`
- Removed unused `useStore` hook import
- Added `loading="lazy"` on all images for performance

## Before / After

**Before:** 6 blank white cards showing "File" text, bottom row hidden below viewport  
**After:** 6 vibrant NFT artworks visible in a compact grid that fits on one screen

## Test Plan

- [x] All 6 art cards display real NFT artwork (3 Okoloto from IPFS, 3 Elemnts from Arweave)
- [ ] Entire ART slide fits within viewport — no vertical scrolling required
- [ ] Scrolling/swiping on the ART slide does NOT trigger slide navigation
- [ ] Clicking any card opens the correct OpenSea collection in a new tab
- [ ] Layout renders correctly on mobile (3 compact columns)
- [ ] Layout renders correctly on desktop (3 columns with slightly more padding)
- [ ] Images load with lazy loading (visible in Network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)